### PR TITLE
fix: correct author profile toggles on subpages

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -2,7 +2,7 @@
 permalink: /home
 title: "Home"
 excerpt: ""
-author_profile: flase
+author_profile: false
 
 ---
 <span id='home'></span>

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -2,7 +2,7 @@
 permalink: /news
 title: "News"
 excerpt: ""
-author_profile: flase
+author_profile: false
 
 ---
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,7 +2,7 @@
 permalink: /publications
 title: "Publications"
 excerpt: ""
-author_profile: flase
+author_profile: false
 
 ---
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -107,3 +107,152 @@ h1:before, .anchor:before {
     background-color: #00369f;
     font-size: .8em;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Custom theming for centered profile, typography, and color palette         */
+/* -------------------------------------------------------------------------- */
+
+@import url("https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@300;400;600;700&display=swap");
+
+body {
+    background: radial-gradient(circle at top, rgba(237, 242, 252, 0.85), rgba(226, 233, 246, 0.95) 45%, #e3e9f5 100%);
+    color: #1b2533;
+    font-family: "Source Sans 3", "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+    font-size: 16px;
+    line-height: 1.7;
+}
+
+.page__content {
+    font-size: 1em;
+}
+
+.page__content h1 {
+    font-size: 2em;
+    color: #0c1f3f;
+    letter-spacing: 0.01em;
+}
+
+.page__content h2 {
+    font-size: 1.7em;
+    color: #12325f;
+}
+
+.page__content h3 {
+    font-size: 1.4em;
+    color: #1b3d73;
+}
+
+.page__content h4 {
+    font-size: 1.22em;
+    color: #1f4378;
+}
+
+.masthead,
+.masthead__inner-wrap,
+.greedy-nav {
+    background-color: #0c1f3f;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.greedy-nav .visible-links a,
+.greedy-nav .hidden-links a,
+.masthead__menu-item {
+    font-size: 0.98em;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: #f4f8ff;
+    text-transform: uppercase;
+}
+
+.greedy-nav .visible-links a:hover,
+.greedy-nav .hidden-links a:hover,
+.masthead__menu-item:hover {
+    color: #7fc8ff;
+}
+
+.profile_box {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 0.65rem;
+    padding: 1.6rem 1.2rem;
+    margin: 2.25rem auto 2.75rem;
+    width: min(320px, 92%);
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 18px;
+    box-shadow: 0 18px 35px rgba(12, 31, 63, 0.08);
+}
+
+.profile_box .author__avatar {
+    display: flex;
+    justify-content: center;
+}
+
+.profile_box .author__avatar img {
+    border-radius: 50%;
+    border: 3px solid rgba(12, 31, 63, 0.12);
+    box-shadow: 0 12px 24px rgba(12, 31, 63, 0.15);
+}
+
+.profile_box .author__content,
+.profile_box .author__urls-wrapper {
+    width: 100%;
+}
+
+.profile_box .author__content .author__name {
+    font-size: 1.5em;
+    font-weight: 700;
+    color: #0c1f3f;
+}
+
+.profile_box .author__bio {
+    font-size: 0.98em;
+    color: #334155;
+}
+
+.profile_box .author__urls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0;
+}
+
+.profile_box .author__urls li,
+.profile_box .author__urls a {
+    font-size: 0.94em;
+    color: #1b2533;
+}
+
+.profile_box .author__urls a:hover {
+    color: #0d63a5;
+}
+
+.profile_box .author__urls li i {
+    color: #0d63a5;
+}
+
+.page__content a {
+    color: #0d63a5;
+}
+
+.page__content a:hover {
+    color: #0a4e80;
+}
+
+#main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+#main > .page {
+    width: min(960px, 100%);
+    float: none;
+}
+
+#main > .page .page__inner-wrap {
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- soften the research-themed background and reduce the global and heading font scales for a calmer reading rhythm
- tighten spacing and typography within the homepage profile card so the avatar block sits naturally in the center column
- center the main article container to keep homepage content aligned with the refined profile presentation
- fix the `author_profile` front matter flag on the Home, News, and Publications subpages so the centered profile card renders consistently

## Testing
- ⚠️ `bundle install` *(fails: rubygems.org returns 403 Forbidden responses)*

------
https://chatgpt.com/codex/tasks/task_e_68e1fe2569288333b8fe88f646bb4a7c