### PR TITLE
style: rebalance profile hero layout

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -8,12 +8,13 @@
     <img src="{{ author.avatar }}" class="author__avatar" alt="{{ author.name }}">
   </div>
 
-  <div class="author__content">
-    <h3 class="author__name">{{ author.name }}</h3>
-    {% if author.bio %}<p class="author__bio">{{ author.bio }}</p>{% endif %}
-  </div>
+  <div class="profile_box__details">
+    <div class="author__content">
+      <h3 class="author__name">{{ author.name }}</h3>
+      {% if author.bio %}<p class="author__bio">{{ author.bio }}</p>{% endif %}
+    </div>
 
-  <div class="author__urls-wrapper">
+    <div class="author__urls-wrapper">
     <!-- <button class="btn btn--inverse">More Info & Contact</button> -->
     <ul class="author__urls social-icons">
       {% if site.description %}
@@ -215,4 +216,6 @@
       {% endif %}
     </div>
   </div>
+</div>
+
 </div>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -2,7 +2,7 @@
 permalink: /home
 title: "Home"
 excerpt: ""
-author_profile: flase
+author_profile: false
 
 ---
 <span id='home'></span>

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -2,7 +2,7 @@
 permalink: /news
 title: "News"
 excerpt: ""
-author_profile: flase
+author_profile: false
 
 ---
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,7 +2,7 @@
 permalink: /publications
 title: "Publications"
 excerpt: ""
-author_profile: flase
+author_profile: false
 
 ---
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -107,3 +107,222 @@ h1:before, .anchor:before {
     background-color: #00369f;
     font-size: .8em;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Custom theming for centered profile, typography, and color palette         */
+/* -------------------------------------------------------------------------- */
+
+@import url("https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@300;400;600;700&display=swap");
+
+body {
+    background: radial-gradient(circle at top, rgba(237, 242, 252, 0.85), rgba(226, 233, 246, 0.95) 45%, #e3e9f5 100%);
+    color: #1b2533;
+    font-family: "Source Sans 3", "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+    font-size: 16px;
+    line-height: 1.7;
+}
+
+.page__content {
+    font-size: 1em;
+}
+
+.page__content h1 {
+    font-size: 2em;
+    color: #0c1f3f;
+    letter-spacing: 0.01em;
+}
+
+.page__content h2 {
+    font-size: 1.7em;
+    color: #12325f;
+}
+
+.page__content h3 {
+    font-size: 1.4em;
+    color: #1b3d73;
+}
+
+.page__content h4 {
+    font-size: 1.22em;
+    color: #1f4378;
+}
+
+.masthead,
+.masthead__inner-wrap,
+.greedy-nav {
+    background-color: #0c1f3f;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.greedy-nav .visible-links a,
+.greedy-nav .hidden-links a,
+.masthead__menu-item {
+    font-size: 0.98em;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: #f4f8ff;
+    text-transform: uppercase;
+}
+
+.greedy-nav .visible-links a:hover,
+.greedy-nav .hidden-links a:hover,
+.masthead__menu-item:hover {
+    color: #7fc8ff;
+}
+
+.profile_box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 1.25rem;
+    padding: 2rem 2.25rem;
+    margin: 1.25rem auto 2rem;
+    width: 100%;
+    max-width: 960px;
+    background: rgba(255, 255, 255, 0.94);
+    border-radius: 24px;
+    box-shadow: 0 18px 34px rgba(12, 31, 63, 0.08);
+}
+
+.profile_box .author__avatar {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex: 0 0 auto;
+}
+
+.profile_box .author__avatar img {
+    border-radius: 50%;
+    border: 3px solid rgba(12, 31, 63, 0.12);
+    box-shadow: 0 12px 24px rgba(12, 31, 63, 0.15);
+    width: clamp(150px, 20vw, 210px);
+    height: clamp(150px, 20vw, 210px);
+    object-fit: cover;
+}
+
+.profile_box__details {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    width: 100%;
+}
+
+.profile_box .author__content,
+.profile_box .author__urls-wrapper {
+    width: 100%;
+}
+
+.profile_box .author__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.profile_box .author__content .author__name {
+    font-size: 1.38em;
+    font-weight: 700;
+    color: #0c1f3f;
+    margin: 0;
+}
+
+.profile_box .author__bio {
+    font-size: 0.98em;
+    color: #314463;
+    margin: 0;
+}
+
+.profile_box .author__urls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0;
+    margin: 0;
+}
+
+.profile_box .author__urls li,
+.profile_box .author__urls a {
+    font-size: 0.95em;
+    color: #1b2533;
+}
+
+.profile_box .author__urls a:hover {
+    color: #0d63a5;
+}
+
+.profile_box .author__urls li i {
+    color: #0d63a5;
+}
+
+@include breakpoint($medium) {
+    .profile_box {
+        flex-direction: row;
+        align-items: center;
+        text-align: left;
+        gap: 2.5rem;
+        padding: 2.25rem 3rem;
+    }
+
+    .profile_box__details {
+        flex: 1 1 auto;
+        flex-direction: row;
+        align-items: stretch;
+        justify-content: space-between;
+        gap: 2rem;
+    }
+
+    .profile_box .author__content {
+        flex: 1 1 45%;
+        justify-content: center;
+        text-align: left;
+    }
+
+    .profile_box .author__content .author__name {
+        font-size: 1.45em;
+    }
+
+    .profile_box .author__bio {
+        font-size: 1em;
+    }
+
+    .profile_box .author__urls-wrapper {
+        flex: 1 1 40%;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+    }
+
+    .profile_box .author__urls {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+        gap: 0.4rem 1rem;
+        align-items: flex-start;
+    }
+}
+
+.page__content a {
+    color: #0d63a5;
+}
+
+.page__content a:hover {
+    color: #0a4e80;
+}
+
+#main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+#main > .page {
+    width: min(960px, 100%);
+    float: none;
+}
+
+#main > .page .page__inner-wrap {
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- wrap the author profile details in a new flex container so the avatar stays on the left and contact links align to the right on wider screens
- expand the profile card to match the main content width while tightening spacing, typography, and avatar sizing for a balanced hero
- switch the contact list to a responsive grid so the profile block stays compact without pushing the rest of the page downward

## Testing
- ⚠️ `bundle install` *(fails: rubygems.org returns 403 Forbidden responses)*

------
https://chatgpt.com/codex/tasks/task_e_68e1fe2569288333b8fe88f646bb4a7c