### PR TITLE
Align sidebar profile card width with main content

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -344,3 +344,12 @@ body {
 #main > .page .page__inner-wrap {
     width: 100%;
 }
+
+#main > .sidebar {
+    width: min(960px, 100%);
+    margin: 0 auto;
+}
+
+#main > .sidebar .profile_box {
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- match the sidebar container width to the main content so the profile card aligns with the body copy
- ensure the profile card stretches to the full sidebar width for a consistent frame

## Testing
- bundle install *(fails: 403 Forbidden while downloading gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e22467d3a883339d2361dec04fa14a