### PR TITLE
Align sidebar profile card width with main content

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -248,32 +248,36 @@ body {
 }
 
 .profile_box .author__urls {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.65rem;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.75rem 1.5rem;
     padding: 0;
     margin: 0;
     text-align: left;
     width: 100%;
-    max-width: 420px;
     list-style: none;
 }
 
 .profile_box .author__urls li {
     display: flex;
     align-items: flex-start;
-    gap: 0.6rem;
+    gap: 0.7rem;
     font-size: 1.02em;
     color: #1b2533;
-    line-height: 1.55;
+    line-height: 1.5;
 }
 
 .profile_box .author__urls li i {
-    flex: 0 0 1.2rem;
+    flex: 0 0 1.35rem;
     color: #0d63a5;
     text-align: center;
-    margin-top: 0.2rem;
+    margin-top: 0.15rem;
+}
+
+.profile_box .author__urls li > a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
 }
 
 .profile_box .author__urls li.author__description {
@@ -317,7 +321,8 @@ body {
     }
 
     .profile_box .author__urls {
-        gap: 0.55rem;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.65rem 1.75rem;
     }
 }
 
@@ -342,5 +347,14 @@ body {
 }
 
 #main > .page .page__inner-wrap {
+    width: 100%;
+}
+
+#main > .sidebar {
+    width: min(960px, 100%);
+    margin: 0 auto;
+}
+
+#main > .sidebar .profile_box {
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- match the sidebar container width to the main content so the profile card aligns with the body copy
- ensure the profile card stretches to the full sidebar width for a consistent frame
- lay out the contact links in a responsive grid with consistent icon and text alignment

## Testing
- bundle exec jekyll build *(fails: command not found: jekyll)*
- bundle install *(fails: 403 Forbidden while downloading gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e22467d3a883339d2361dec04fa14a