### PR TITLE
Reorganize author profile layout

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -4,16 +4,18 @@
 
 <div itemscope itemtype="http://schema.org/Person" class="profile_box">
 
-  <div class="author__avatar">
-    <img src="{{ author.avatar }}" class="author__avatar" alt="{{ author.name }}">
-  </div>
+  <div class="profile_box__identity">
+    <div class="author__avatar">
+      <img src="{{ author.avatar }}" class="author__avatar" alt="{{ author.name }}">
+    </div>
 
-  <div class="profile_box__details">
     <div class="author__content">
       <h3 class="author__name">{{ author.name }}</h3>
       {% if author.bio %}<p class="author__bio">{{ author.bio }}</p>{% endif %}
     </div>
+  </div>
 
+  <div class="profile_box__details">
     <div class="author__urls-wrapper">
     <!-- <button class="btn btn--inverse">More Info & Contact</button> -->
     <ul class="author__urls social-icons">
@@ -21,10 +23,10 @@
         <li class="author__description"><i class="fa fa-fw fa-id-card" aria-hidden="true"></i><span>{{ site.description }}</span></li>
       {% endif %}
       {% if author.location %}
-        <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ author.location }}</li>
+        <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i><span>{{ author.location }}</span></li>
       {% endif %}
       {% if author.employer %}
-        <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i> {{ author.employer }}</li>
+        <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i><span>{{ author.employer }}</span></li>
       {% endif %}
       {% if author.uri %}
         <li><a href="{{ author.uri }}"><i class="fas fa-fw fa-link" aria-hidden="true"></i> Website</a></li>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -88,13 +88,18 @@
 }
 
 $scroll_offset : 2em;
-h1:before, .anchor:before { 
-    content: ''; 
-    display: block; 
-    position: relative; 
-    width: 0; 
-    height: $scroll_offset; 
+h1:before, .anchor:before {
+    content: '';
+    display: block;
+    position: relative;
+    width: 0;
+    height: $scroll_offset;
     margin-top: -$scroll_offset;
+}
+
+.anchor {
+    display: block;
+    position: relative;
 }
 
 .badge {
@@ -176,9 +181,8 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     text-align: center;
-    gap: 2rem;
+    gap: clamp(2rem, 5vw, 2.75rem);
     padding: clamp(2.5rem, 6vw, 3.75rem);
     margin: clamp(1.5rem, 4vw, 3rem) auto;
     width: min(100%, 960px);
@@ -187,109 +191,122 @@ body {
     box-shadow: 0 28px 52px rgba(12, 31, 63, 0.14);
 }
 
+.profile_box__identity {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.15rem;
+}
+
 .profile_box .author__avatar {
     display: flex;
     justify-content: center;
     align-items: center;
     flex: 0 0 auto;
-    width: clamp(180px, 24vw, 240px);
+    width: clamp(200px, 28vw, 260px);
 }
 
 .profile_box .author__avatar img {
     border-radius: 50%;
-    border: 3px solid rgba(12, 31, 63, 0.12);
-    box-shadow: 0 18px 32px rgba(12, 31, 63, 0.18);
-    width: clamp(190px, 22vw, 230px);
-    height: clamp(190px, 22vw, 230px);
+    border: 4px solid rgba(12, 31, 63, 0.1);
+    box-shadow: 0 22px 36px rgba(12, 31, 63, 0.18);
+    width: clamp(210px, 26vw, 260px);
+    height: clamp(210px, 26vw, 260px);
     object-fit: cover;
-}
-
-.profile_box__details {
-    display: grid;
-    width: 100%;
-    gap: 1.75rem 2.5rem;
-    align-items: start;
-    justify-items: stretch;
-}
-
-.profile_box .author__content,
-.profile_box .author__urls-wrapper {
-    width: 100%;
+    background: #fff;
 }
 
 .profile_box .author__content {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.6rem;
-    text-align: inherit;
+    gap: 0.45rem;
+    max-width: 32ch;
 }
 
 .profile_box .author__content .author__name {
-    font-size: clamp(1.9rem, 3vw, 2.35rem);
+    font-size: clamp(2rem, 3.2vw, 2.5rem);
     font-weight: 700;
     color: #0c1f3f;
     margin: 0;
+    letter-spacing: 0.01em;
 }
 
 .profile_box .author__bio {
     font-size: 1.05em;
-    color: #314463;
+    color: #2b3b57;
     margin: 0;
-    max-width: 36ch;
+    line-height: 1.6;
+}
+
+.profile_box__details {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    width: 100%;
 }
 
 .profile_box .author__urls-wrapper {
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    width: 100%;
-    margin-inline: auto;
+    width: min(100%, 620px);
 }
 
 .profile_box .author__urls {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.65rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.85rem 1.75rem;
     padding: 0;
     margin: 0;
     text-align: left;
     width: 100%;
-    max-width: 420px;
     list-style: none;
 }
 
 .profile_box .author__urls li {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.6rem;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: start;
+    column-gap: 0.65rem;
     font-size: 1.02em;
     color: #1b2533;
     line-height: 1.55;
 }
 
 .profile_box .author__urls li i {
-    flex: 0 0 1.2rem;
     color: #0d63a5;
     text-align: center;
-    margin-top: 0.2rem;
+    margin-top: 0.1rem;
+    font-size: 1.05em;
+}
+
+.profile_box .author__urls li > a,
+.profile_box .author__urls li > span,
+.profile_box .author__urls li > div {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
 }
 
 .profile_box .author__urls li.author__description {
     color: #314463;
-}
-
-.profile_box .author__urls li.author__description span {
-    flex: 1 1 auto;
+    font-weight: 500;
 }
 
 .profile_box .author__urls a {
     color: inherit;
+    font-weight: 500;
 }
 
 .profile_box .author__urls a:hover {
     color: #0d63a5;
+}
+
+.profile_box .author__urls_sm {
+    display: flex;
+    justify-content: center;
+    gap: 1.1rem;
+    font-size: 1.6em;
+    margin-top: 0.5rem;
 }
 
 @include breakpoint($medium) {
@@ -297,27 +314,38 @@ body {
         flex-direction: row;
         align-items: stretch;
         text-align: left;
-        gap: clamp(2.5rem, 4vw, 3.5rem);
-        padding: clamp(3rem, 6vw, 4rem) clamp(3rem, 6vw, 4.5rem);
+        gap: clamp(2.75rem, 5vw, 4rem);
+        padding: clamp(3rem, 6vw, 4rem) clamp(3rem, 6vw, 4.75rem);
     }
 
-    .profile_box__details {
-        grid-template-columns: minmax(0, 0.58fr) minmax(260px, 0.42fr);
-        justify-items: stretch;
+    .profile_box__identity {
+        align-items: center;
+        text-align: center;
+        gap: 1.25rem;
+        flex: 0 0 clamp(260px, 28vw, 320px);
     }
 
     .profile_box .author__content {
-        justify-content: center;
+        align-items: center;
+    }
+
+    .profile_box__details {
         align-items: flex-start;
     }
 
     .profile_box .author__urls-wrapper {
-        justify-content: flex-start;
-        margin-inline: 0;
+        width: 100%;
     }
 
     .profile_box .author__urls {
-        gap: 0.55rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 0.7rem 2rem;
+    }
+
+    .profile_box .author__urls_sm {
+        justify-content: flex-start;
+        font-size: 1.4em;
+        gap: 0.85rem;
     }
 }
 
@@ -342,5 +370,14 @@ body {
 }
 
 #main > .page .page__inner-wrap {
+    width: 100%;
+}
+
+#main > .sidebar {
+    width: min(960px, 100%);
+    margin: 0 auto;
+}
+
+#main > .sidebar .profile_box {
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- wrap the author avatar and text in a dedicated identity column so the name appears below the photo
- enlarge the portrait dimensions and retune spacing for the profile card to better match the page width
- realign the contact list into a balanced responsive grid with consistent icon/text alignment

## Testing
- bundle exec jekyll build *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68e22467d3a883339d2361dec04fa14a