### PR TITLE
Refine homepage profile layout

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -8,14 +8,16 @@
     <div class="author__avatar">
       <img src="{{ author.avatar }}" class="author__avatar" alt="{{ author.name }}">
     </div>
-
-    <div class="author__content">
-      <h3 class="author__name">{{ author.name }}</h3>
-      {% if author.bio %}<p class="author__bio">{{ author.bio }}</p>{% endif %}
-    </div>
   </div>
 
   <div class="profile_box__details">
+    <div class="author__content">
+      <h3 class="author__name">{{ author.name }}</h3>
+      {% if author.bio %}
+        <div class="author__bio">{{ author.bio | markdownify }}</div>
+      {% endif %}
+    </div>
+
     <div class="author__urls-wrapper">
     <!-- <button class="btn btn--inverse">More Info & Contact</button> -->
     <ul class="author__urls social-icons">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -183,7 +183,7 @@ body {
     align-items: center;
     text-align: center;
     gap: clamp(2rem, 5vw, 2.75rem);
-    padding: clamp(2.5rem, 6vw, 3.75rem);
+    padding: clamp(2.75rem, 6vw, 4rem);
     margin: clamp(1.5rem, 4vw, 3rem) auto;
     width: min(100%, 960px);
     background: rgba(255, 255, 255, 0.98);
@@ -195,7 +195,6 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1.15rem;
 }
 
 .profile_box .author__avatar {
@@ -203,24 +202,24 @@ body {
     justify-content: center;
     align-items: center;
     flex: 0 0 auto;
-    width: clamp(200px, 28vw, 260px);
+    width: clamp(220px, 32vw, 320px);
 }
 
 .profile_box .author__avatar img {
     border-radius: 50%;
     border: 4px solid rgba(12, 31, 63, 0.1);
     box-shadow: 0 22px 36px rgba(12, 31, 63, 0.18);
-    width: clamp(210px, 26vw, 260px);
-    height: clamp(210px, 26vw, 260px);
+    width: clamp(230px, 30vw, 320px);
+    height: clamp(230px, 30vw, 320px);
     object-fit: cover;
 }
 
 .profile_box__details {
-    display: grid;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
     width: 100%;
-    gap: 1.5rem 2.25rem;
-    align-items: start;
-    justify-items: start;
 }
 
 .profile_box .author__content,
@@ -232,12 +231,13 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.55rem;
+    gap: 0.8rem;
     text-align: left;
+    max-width: 100%;
 }
 
 .profile_box .author__content .author__name {
-    font-size: clamp(2rem, 3.2vw, 2.5rem);
+    font-size: clamp(1.9rem, 2.8vw, 2.25rem);
     font-weight: 700;
     color: #0c1f3f;
     margin: 0;
@@ -245,28 +245,28 @@ body {
 }
 
 .profile_box .author__bio {
-    font-size: 1.03em;
-    color: #314463;
-    margin: 0;
-    max-width: 42ch;
+    font-size: 1.08em;
+    color: #2b3b56;
+    line-height: 1.65;
+    max-width: 46ch;
 }
 
-.profile_box__details {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
-    width: 100%;
+.profile_box .author__bio p {
+    margin: 0;
+}
+
+.profile_box .author__bio p + p {
+    margin-top: 0.75rem;
 }
 
 .profile_box .author__urls-wrapper {
-    width: min(100%, 620px);
+    width: min(100%, 640px);
 }
 
 .profile_box .author__urls {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    gap: 0.75rem 1.5rem;
+    gap: 0.85rem;
     padding: 0;
     margin: 0;
     text-align: left;
@@ -277,14 +277,14 @@ body {
 .profile_box .author__urls li {
     display: flex;
     align-items: flex-start;
-    gap: 0.7rem;
-    font-size: 1.02em;
+    gap: 0.75rem;
+    font-size: 1.08em;
     color: #1b2533;
-    line-height: 1.5;
+    line-height: 1.55;
 }
 
 .profile_box .author__urls li i {
-    flex: 0 0 1.35rem;
+    flex: 0 0 1.45rem;
     color: #0d63a5;
     text-align: center;
     margin-top: 0.15rem;
@@ -305,8 +305,8 @@ body {
 }
 
 .profile_box .author__urls li.author__description {
-    color: #314463;
-    font-weight: 500;
+    color: #1e3352;
+    font-weight: 600;
 }
 
 .profile_box .author__urls a {
@@ -329,34 +329,28 @@ body {
 @include breakpoint($medium) {
     .profile_box {
         flex-direction: row;
-        align-items: stretch;
+        align-items: flex-start;
         text-align: left;
-        gap: clamp(2.75rem, 5vw, 4rem);
-        padding: clamp(3rem, 6vw, 4rem) clamp(3rem, 6vw, 4.75rem);
+        gap: clamp(3rem, 5vw, 4.5rem);
+        padding: clamp(3.25rem, 6vw, 4.5rem) clamp(3rem, 6vw, 5rem);
     }
 
     .profile_box__identity {
         align-items: center;
-        text-align: center;
-        gap: 1.25rem;
-        flex: 0 0 clamp(260px, 28vw, 320px);
-    }
-
-    .profile_box .author__content {
-        align-items: center;
+        flex: 0 0 clamp(260px, 32vw, 340px);
     }
 
     .profile_box__details {
         align-items: flex-start;
     }
 
-    .profile_box .author__urls-wrapper {
-        width: 100%;
+    .profile_box .author__content {
+        align-items: flex-start;
+        max-width: 520px;
     }
 
     .profile_box .author__urls {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 0.65rem 1.75rem;
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 


### PR DESCRIPTION
## Summary
- restructure the author profile include so that the biography and contact details sit to the right of the portrait image
- enlarge the avatar container and tune type scales and spacing for improved readability of the main headline and detail rows
- keep the profile detail list in a single-column flow to avoid the previous 2x2 arrangement

## Testing
- Not run (environment missing Jekyll dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e22bd52b9c833389f6448aef579866