### PR TITLE
Disable sticky sidebar from overlapping content

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -386,3 +386,8 @@ body {
 #main > .sidebar .profile_box {
     width: 100%;
 }
+
+#main > .sidebar.sticky {
+    position: static !important;
+    top: auto !important;
+}


### PR DESCRIPTION
## Summary
- override the layout-specific sidebar styles so the profile section no longer stays fixed over the page content

## Testing
- bundler install *(fails: unable to download gems in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22d8db7f48333a19f021a110dd756