### PR TITLE
Refine author card contact styling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,8 +24,9 @@ author:
   name             : "Xiaoyu Xu \n (许晓宇)"
   avatar           : "images/android-chrome-512x512.png"
   bio              : |
-    📧 Email: xiaoyu0910.xu@connect.polyu.hk
-    👥 Group: <a href="https://www.astaple.com/" target="_blank">ASTAPLE Lab</a>
+    <strong>Email:</strong> <a href="mailto:xiaoyu0910.xu@connect.polyu.hk">xiaoyu0910.xu@connect.polyu.hk</a>
+
+    <strong>Group:</strong> <a href="https://www.astaple.com/" target="_blank" rel="noopener">ASTAPLE Lab</a>
 
   location         : "Hong Kong, China"
   employer         : 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -245,18 +245,36 @@ body {
 }
 
 .profile_box .author__bio {
-    font-size: 1.08em;
+    font-size: 1.22em;
     color: #2b3b56;
     line-height: 1.65;
     max-width: 46ch;
+    font-weight: 500;
 }
 
 .profile_box .author__bio p {
     margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
 }
 
 .profile_box .author__bio p + p {
-    margin-top: 0.75rem;
+    margin-top: 0.85rem;
+}
+
+.profile_box .author__bio p strong {
+    color: #0c1f3f;
+    font-weight: 700;
+}
+
+.profile_box .author__bio a {
+    color: #0d63a5;
+    font-weight: 600;
+}
+
+.profile_box .author__bio a:hover {
+    text-decoration: underline;
 }
 
 .profile_box .author__urls-wrapper {
@@ -385,4 +403,9 @@ body {
 
 #main > .sidebar .profile_box {
     width: 100%;
+}
+
+#main > .sidebar.sticky {
+    position: static !important;
+    top: auto !important;
 }


### PR DESCRIPTION
## Summary
- override the layout-specific sidebar styles so the profile section no longer stays fixed over the page content
- highlight the author email and group information without the decorative icons so the contact details are easier to read

## Testing
- bundle install *(fails: unable to download gems in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22d8db7f48333a19f021a110dd756