### PR TITLE
Tighten author profile card layout

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -182,10 +182,10 @@ body {
     flex-direction: column;
     align-items: center;
     text-align: center;
-    gap: clamp(1.25rem, 3vw, 2rem);
-    padding: clamp(1.5rem, 3.5vw, 2.5rem);
-    margin: clamp(1.25rem, 3vw, 2.5rem) auto;
-    width: min(100%, 640px);
+    gap: clamp(1rem, 2.5vw, 1.75rem);
+    padding: clamp(1.25rem, 3vw, 2.25rem);
+    margin: clamp(1.1rem, 2.5vw, 2.25rem) auto;
+    width: min(100%, 560px);
     background: rgba(255, 255, 255, 0.98);
     border-radius: 26px;
     box-shadow: 0 24px 44px rgba(12, 31, 63, 0.12);
@@ -202,15 +202,15 @@ body {
     justify-content: center;
     align-items: center;
     flex: 0 0 auto;
-    width: clamp(180px, 28vw, 260px);
+    width: clamp(170px, 26vw, 240px);
 }
 
 .profile_box .author__avatar img {
     border-radius: 50%;
     border: 4px solid rgba(12, 31, 63, 0.1);
     box-shadow: 0 18px 30px rgba(12, 31, 63, 0.16);
-    width: clamp(190px, 26vw, 260px);
-    height: clamp(190px, 26vw, 260px);
+    width: clamp(180px, 24vw, 240px);
+    height: clamp(180px, 24vw, 240px);
     max-width: 100%;
     aspect-ratio: 1 / 1;
     display: block;
@@ -223,7 +223,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: clamp(1.5rem, 3vw, 2.25rem);
+    gap: clamp(1.25rem, 2.5vw, 2rem);
     width: 100%;
 }
 
@@ -283,7 +283,7 @@ body {
 }
 
 .profile_box .author__urls-wrapper {
-    width: min(100%, 420px);
+    width: min(100%, 380px);
 }
 
 .profile_box .author__urls {
@@ -350,13 +350,13 @@ body {
         flex-direction: row;
         align-items: flex-start;
         text-align: left;
-        gap: clamp(2.5rem, 4vw, 3.75rem);
-        padding: clamp(2.75rem, 5vw, 4rem) clamp(2.5rem, 5vw, 4.25rem);
+        gap: clamp(2rem, 3.5vw, 3.25rem);
+        padding: clamp(2.25rem, 4.25vw, 3.5rem) clamp(2rem, 4.5vw, 3.5rem);
     }
 
     .profile_box__identity {
         align-items: center;
-        flex: 0 0 clamp(260px, 32vw, 340px);
+        flex: 0 0 clamp(230px, 30vw, 300px);
     }
 
     .profile_box__details {
@@ -365,7 +365,7 @@ body {
 
     .profile_box .author__content {
         align-items: flex-start;
-        max-width: 520px;
+        max-width: 460px;
     }
 
     .profile_box .author__urls {


### PR DESCRIPTION
## Summary
- tighten the author profile card by reducing its max width, spacing, and padding so the white panel appears more compact

## Testing
- not run (bundle install fails with 403 errors when fetching gems)


------
https://chatgpt.com/codex/tasks/task_e_68e2390791f0833384bf540b0bf0654c