### PR TITLE
Adjust profile card layout spacing

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -176,16 +176,17 @@ body {
     color: #7fc8ff;
 }
 
+
 .profile_box {
     position: relative;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: clamp(1rem, 2.5vw, 1.75rem);
-    padding: clamp(1.25rem, 3vw, 2.25rem);
+    align-items: flex-start;
+    text-align: left;
+    gap: clamp(0.75rem, 2vw, 1.4rem);
+    padding: clamp(1rem, 2.4vw, 1.85rem);
     margin: clamp(1.1rem, 2.5vw, 2.25rem) auto;
-    width: min(100%, 560px);
+    width: min(100%, 520px);
     background: rgba(255, 255, 255, 0.98);
     border-radius: 26px;
     box-shadow: 0 24px 44px rgba(12, 31, 63, 0.12);
@@ -194,7 +195,8 @@ body {
 .profile_box__identity {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
+    width: 100%;
 }
 
 .profile_box .author__avatar {
@@ -222,8 +224,8 @@ body {
 .profile_box__details {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    gap: clamp(1.25rem, 2.5vw, 2rem);
+    align-items: flex-start;
+    gap: clamp(1rem, 2.1vw, 1.6rem);
     width: 100%;
 }
 
@@ -236,7 +238,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.8rem;
+    gap: 0.6rem;
     text-align: left;
     max-width: 100%;
 }
@@ -252,7 +254,7 @@ body {
 .profile_box .author__bio {
     font-size: 1.22em;
     color: #2b3b56;
-    line-height: 1.65;
+    line-height: 1.52;
     max-width: 46ch;
     font-weight: 500;
 }
@@ -265,7 +267,7 @@ body {
 }
 
 .profile_box .author__bio p + p {
-    margin-top: 0.85rem;
+    margin-top: 0.55rem;
 }
 
 .profile_box .author__bio p strong {
@@ -289,7 +291,7 @@ body {
 .profile_box .author__urls {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    gap: 0.85rem;
+    gap: 0.6rem;
     padding: 0;
     margin: 0;
     text-align: left;
@@ -298,33 +300,33 @@ body {
 }
 
 .profile_box .author__urls li {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto 1fr;
     align-items: flex-start;
-    gap: 0.75rem;
+    column-gap: 0.55rem;
     font-size: 1.08em;
     color: #1b2533;
-    line-height: 1.55;
+    line-height: 1.38;
+    width: 100%;
 }
 
 .profile_box .author__urls li i {
-    flex: 0 0 1.45rem;
+    grid-row: 1;
+    grid-column: 1;
     color: #0d63a5;
     text-align: center;
     margin-top: 0.15rem;
 }
 
-.profile_box .author__urls li > a {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-}
-
 .profile_box .author__urls li > a,
 .profile_box .author__urls li > span,
 .profile_box .author__urls li > div {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
+    grid-column: 2;
+    grid-row: 1;
+    display: block;
+    min-width: 0;
+    text-align: left;
+    word-break: break-word;
 }
 
 .profile_box .author__urls li.author__description {
@@ -350,12 +352,12 @@ body {
         flex-direction: row;
         align-items: flex-start;
         text-align: left;
-        gap: clamp(2rem, 3.5vw, 3.25rem);
-        padding: clamp(2.25rem, 4.25vw, 3.5rem) clamp(2rem, 4.5vw, 3.5rem);
+        gap: clamp(1.6rem, 3vw, 2.75rem);
+        padding: clamp(1.75rem, 3.8vw, 3rem) clamp(1.6rem, 3.8vw, 3.1rem);
     }
 
     .profile_box__identity {
-        align-items: center;
+        align-items: flex-start;
         flex: 0 0 clamp(230px, 30vw, 300px);
     }
 


### PR DESCRIPTION
## Summary
- align the profile card content to the left for better readability
- reduce the profile box padding and width to make the white frame more compact
- tighten line spacing within the bio and contact list for a denser layout
- restructure the contact list layout so multi-line entries stay left-aligned with the rest of the card

## Testing
- Not run (dependency installation blocked by 403 Forbidden when executing `bundle install`)


------
https://chatgpt.com/codex/tasks/task_e_68e23aa71f048333abfe345bf81c1e3d