### PR TITLE
Align author contact links to the left

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -24,36 +24,23 @@
       {% if site.description %}
         <li class="author__description"><i class="fa fa-fw fa-id-card" aria-hidden="true"></i><span>{{ site.description }}</span></li>
       {% endif %}
-      {% assign inline_count = 0 %}
-      {% capture inline_items %}
-        {% if author.location %}
-          {% assign inline_count = inline_count | plus: 1 %}
-          <span class="author__inline-item">
-            <i class="fa fa-fw fa-map-marker" aria-hidden="true"></i>
-            <span>{{ author.location }}</span>
-          </span>
-        {% endif %}
-        {% if author.github %}
-          {% assign inline_count = inline_count | plus: 1 %}
-          <span class="author__inline-item">
-            <a href="https://github.com/{{ author.github }}">
-              <i class="fab fa-fw fa-github" aria-hidden="true"></i>
-              Github
-            </a>
-          </span>
-        {% endif %}
-        {% if author.googlescholar %}
-          {% assign inline_count = inline_count | plus: 1 %}
-          <span class="author__inline-item">
-            <a href="{{ author.googlescholar }}">
-              <i class="fas fa-fw fa-graduation-cap"></i>
-              Google Scholar
-            </a>
-          </span>
-        {% endif %}
-      {% endcapture %}
-      {% if inline_count > 0 %}
-        <li class="author__inline-group">{{ inline_items | strip_newlines }}</li>
+      {% if author.location %}
+        <li>
+          <i class="fa fa-fw fa-map-marker" aria-hidden="true"></i>
+          <span>{{ author.location }}</span>
+        </li>
+      {% endif %}
+      {% if author.github %}
+        <li>
+          <i class="fab fa-fw fa-github" aria-hidden="true"></i>
+          <a href="https://github.com/{{ author.github }}">Github</a>
+        </li>
+      {% endif %}
+      {% if author.googlescholar %}
+        <li>
+          <i class="fas fa-fw fa-graduation-cap" aria-hidden="true"></i>
+          <a href="{{ author.googlescholar }}">Google Scholar</a>
+        </li>
       {% endif %}
       {% if author.employer %}
         <li><i class="fa fa-fw fa-map-marker" aria-hidden="true"></i><span>{{ author.employer }}</span></li>

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -152,7 +152,7 @@
   font-family: $sans-serif;
   z-index: 10;
   position: relative;
-  margin-left: auto;
+  margin-left: 0;
   cursor: pointer;
 
   li:last-child {
@@ -249,26 +249,6 @@
 
     &:hover {
       text-decoration: underline;
-    }
-  }
-}
-
-.author__inline-group {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
-
-  .author__inline-item {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-
-    > a {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace the inline contact group in the author profile with individual list items so the email, group, description, and other links line up on the left
- simplify the sidebar styles by removing the unused inline group rules and ensuring the profile links container no longer shifts to the right

## Testing
- bundle install *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e24521302c8333b0c1a30119606e61