### PR TITLE
Reduce profile card spacing

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -183,10 +183,10 @@ body {
     flex-direction: column;
     align-items: flex-start;
     text-align: left;
-    gap: clamp(0.75rem, 2vw, 1.4rem);
-    padding: clamp(1rem, 2.4vw, 1.85rem);
-    margin: clamp(1.1rem, 2.5vw, 2.25rem) auto;
-    width: min(100%, 520px);
+    gap: clamp(0.6rem, 1.7vw, 1.15rem);
+    padding: clamp(0.85rem, 2vw, 1.5rem);
+    margin: clamp(0.9rem, 2.2vw, 1.9rem) auto;
+    width: min(100%, 460px);
     background: rgba(255, 255, 255, 0.98);
     border-radius: 26px;
     box-shadow: 0 24px 44px rgba(12, 31, 63, 0.12);
@@ -225,7 +225,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: clamp(1rem, 2.1vw, 1.6rem);
+    gap: clamp(0.65rem, 1.6vw, 1.1rem);
     width: 100%;
 }
 
@@ -255,7 +255,7 @@ body {
     font-size: 1.22em;
     color: #2b3b56;
     line-height: 1.52;
-    max-width: 46ch;
+    max-width: 40ch;
     font-weight: 500;
 }
 
@@ -285,7 +285,7 @@ body {
 }
 
 .profile_box .author__urls-wrapper {
-    width: min(100%, 380px);
+    width: min(100%, 340px);
 }
 
 .profile_box .author__urls {


### PR DESCRIPTION
## Summary
- tighten the profile card spacing so the gap below the group line is smaller
- shrink the profile card container width and text column for a closer white frame

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 *(fails: bundler install blocked by 403 Forbidden when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e246eacdb483339dc2fc04852d833d