### PR TITLE
Tighten profile card spacing

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -183,10 +183,10 @@ body {
     flex-direction: column;
     align-items: flex-start;
     text-align: left;
-    gap: clamp(0.6rem, 1.7vw, 1.15rem);
-    padding: clamp(0.85rem, 2vw, 1.5rem);
-    margin: clamp(0.9rem, 2.2vw, 1.9rem) auto;
-    width: min(100%, 460px);
+    gap: clamp(0.45rem, 1.2vw, 0.9rem);
+    padding: clamp(0.7rem, 1.6vw, 1.2rem);
+    margin: clamp(0.75rem, 1.8vw, 1.5rem) auto;
+    width: min(100%, 420px);
     background: rgba(255, 255, 255, 0.98);
     border-radius: 26px;
     box-shadow: 0 24px 44px rgba(12, 31, 63, 0.12);
@@ -225,7 +225,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: clamp(0.65rem, 1.6vw, 1.1rem);
+    gap: clamp(0.45rem, 1.1vw, 0.9rem);
     width: 100%;
 }
 
@@ -238,7 +238,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.6rem;
+    gap: 0.45rem;
     text-align: left;
     max-width: 100%;
 }
@@ -291,7 +291,7 @@ body {
 .profile_box .author__urls {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    gap: 0.6rem;
+    gap: 0.45rem;
     padding: 0;
     margin: 0;
     text-align: left;
@@ -303,10 +303,10 @@ body {
     display: grid;
     grid-template-columns: auto 1fr;
     align-items: flex-start;
-    gap: 0.55rem;
+    gap: 0.45rem;
     font-size: 1.08em;
     color: #1b2533;
-    line-height: 1.38;
+    line-height: 1.34;
 }
 
 .profile_box .author__urls li i {
@@ -351,8 +351,8 @@ body {
         flex-direction: row;
         align-items: flex-start;
         text-align: left;
-        gap: clamp(1.6rem, 3vw, 2.75rem);
-        padding: clamp(1.75rem, 3.8vw, 3rem) clamp(1.6rem, 3.8vw, 3.1rem);
+        gap: clamp(1.1rem, 2.5vw, 2.1rem);
+        padding: clamp(1.2rem, 3vw, 2.2rem) clamp(1.1rem, 3vw, 2.3rem);
     }
 
     .profile_box__identity {


### PR DESCRIPTION
## Summary
- reduce the profile card spacing so the “Group” entry sits closer to the content below it
- shrink the profile card padding and width so the white background hugs the content more closely on all breakpoints

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 --livereload --detach *(fails: bundler: command not found: jekyll)*
- bundle install *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e24901a1648333b1b1b9d63ae73354